### PR TITLE
56 improvement merge result sprint result

### DIFF
--- a/src/SequelFormula_data_updates.sql
+++ b/src/SequelFormula_data_updates.sql
@@ -270,6 +270,18 @@ UPDATE [dbo].[sprintResults] SET time_converted = TRY_CONVERT(time(3),[TimeDiffe
 
 GO
 
+INSERT INTO [dbo].[resultsNew](raceId,resultType, driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap, rank, statusId, positionTextID, fastestLapTime, fastestLapSpeed, time)
+SELECT 
+raceid,1,driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap, rank, statusId, positionTextID, fastestLapTime, fastestLapSpeed, time
+FROM 
+[dbo].[results]
+
+INSERT INTO [dbo].[resultsNew](raceId,resultType, driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap,  statusId, positionTextID, fastestLapTime,  time)
+SELECT 
+raceid,2,driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap,  statusId, positionTextID, fastestLapTime,  time
+FROM 
+[dbo].[sprintResults]
+
 ALTER TABLE [dbo].[constructors] DROP COLUMN [nationality]; 
 
 ALTER TABLE [dbo].[circuits] DROP COLUMN [location]; 
@@ -300,6 +312,10 @@ ALTER TABLE [dbo].[sprintResults] DROP COLUMN [positionText];
 ALTER TABLE [dbo].[sprintResults] DROP COLUMN [timeDifference];
 ALTER TABLE [dbo].[sprintResults] DROP COLUMN [time];
 
+DROP TABLE [dbo].[results];
+DROP TABLE [dbo].[Sprintresults];
+
+EXEC sp_rename 'resultsnew', 'results';
 EXEC sp_rename 'dbo.sprintResults.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
 EXEC sp_rename 'dbo.results.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
 EXEC sp_rename 'dbo.results.fastestLapSpeed_Decimal', 'fastestLapSpeed', 'COLUMN';

--- a/src/SequelFormula_data_updates.sql
+++ b/src/SequelFormula_data_updates.sql
@@ -270,33 +270,119 @@ UPDATE [dbo].[sprintResults] SET time_converted = TRY_CONVERT(time(3),[TimeDiffe
 
 GO
 
-INSERT INTO [dbo].[resultsNew](raceId,resultType, driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap, rank, statusId, positionTextID, fastestLapTime, fastestLapSpeed, time)
-SELECT 
-raceid,1,driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap, rank, statusId, positionTextID, fastestLapTime, fastestLapSpeed, time
-FROM 
-[dbo].[results]
+ALTER TABLE [dbo].[results] DROP COLUMN [positionText];
+ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapTime];
+ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapSpeed];
+ALTER TABLE [dbo].[results] DROP COLUMN [time];
+ALTER TABLE [dbo].[results] DROP COLUMN [timeDifference];
 
-INSERT INTO [dbo].[resultsNew](raceId,resultType, driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap,  statusId, positionTextID, fastestLapTime,  time)
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [fastestLapTime];
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [positionText];
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [timeDifference];
+ALTER TABLE [dbo].[sprintResults] DROP COLUMN [time];
+
+EXEC sp_rename 'dbo.sprintResults.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
+EXEC sp_rename 'dbo.results.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
+EXEC sp_rename 'dbo.results.fastestLapSpeed_Decimal', 'fastestLapSpeed', 'COLUMN';
+EXEC sp_rename 'dbo.results.time_converted', 'time', 'COLUMN';
+EXEC sp_rename 'dbo.sprintResults.time_converted', 'time', 'COLUMN';
+
+GO
+
+INSERT INTO [dbo].[resultsNew]
+(
+	[raceId],
+	[resultType], 
+	[driverId], 
+	[constructorId], 
+	[number], 
+	[grid], 
+	[position], 
+	[positionOrder], 
+	[points], 
+	[laps], 
+	[milliseconds], 
+	[fastestLap], 
+	[rank], 
+	[statusId], 
+	[positionTextID], 
+	[fastestLapTime], 
+	[fastestLapSpeed], 
+	[time]
+)
 SELECT 
-raceid,2,driverId, constructorId, number, grid, position, positionOrder, points, laps, milliseconds, fastestLap,  statusId, positionTextID, fastestLapTime,  time
+	[raceid],
+	'1',
+	[driverId], 
+	[constructorId], 
+	[number], 
+	[grid], 
+	[position], 
+	[positionOrder], 
+	[points], 
+	[laps], 
+	[milliseconds], 
+	[fastestLap], 
+	[rank], 
+	[statusId], 
+	[positionTextID], 
+	[fastestLapTime], 
+	[fastestLapSpeed],
+	[time]
 FROM 
-[dbo].[sprintResults]
+	[dbo].[results]
+
+GO
+
+INSERT INTO [dbo].[resultsNew]
+(
+	[raceId],
+	[resultType], 
+	[driverId],
+	[constructorId], 
+	[number], 
+	[grid], 
+	[position], 
+	[positionOrder], 
+	[points], 
+	[laps], 
+	[milliseconds], 
+	[fastestLap],  
+	[statusId], 
+	[positionTextID], 
+	[fastestLapTime],  
+	[time]
+)
+SELECT 
+	[raceid],
+	'2',
+	[driverId], 
+	[constructorId], 
+	[number], 
+	[grid], 
+	[position],
+	[positionOrder], 
+	[points], 
+	[laps], 
+	[milliseconds], 
+	[fastestLap],  
+	[statusId], 
+	[positionTextID], 
+	[fastestLapTime],  
+	[time]
+FROM 
+	[dbo].[sprintResults]
+
+GO
 
 ALTER TABLE [dbo].[constructors] DROP COLUMN [nationality]; 
 
 ALTER TABLE [dbo].[circuits] DROP COLUMN [location]; 
 ALTER TABLE [dbo].[circuits] DROP COLUMN [country]; 
 
-ALTER TABLE [dbo].[results] DROP COLUMN [positionText];
-ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapTime];
-ALTER TABLE [dbo].[results] DROP COLUMN [fastestLapSpeed];
-
 ALTER TABLE [dbo].[qualifying] DROP COLUMN q1;
 ALTER TABLE [dbo].[qualifying] DROP COLUMN q2;
 ALTER TABLE [dbo].[qualifying] DROP COLUMN q3;
-
-ALTER TABLE [dbo].[results] DROP COLUMN [time];
-ALTER TABLE [dbo].[results] DROP COLUMN [timeDifference];
 
 ALTER TABLE [dbo].[drivers] DROP COLUMN [nationality]; 
 
@@ -307,22 +393,12 @@ ALTER TABLE [dbo].[driverStandings] DROP COLUMN [positionText];
 ALTER TABLE [dbo].[pitStops] DROP COLUMN [duration];
 ALTER TABLE [dbo].[lapTimes] DROP COLUMN [time];
 
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [fastestLapTime];
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [positionText];
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [timeDifference];
-ALTER TABLE [dbo].[sprintResults] DROP COLUMN [time];
-
 DROP TABLE [dbo].[results];
 DROP TABLE [dbo].[Sprintresults];
 
 EXEC sp_rename 'resultsnew', 'results';
-EXEC sp_rename 'dbo.sprintResults.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
-EXEC sp_rename 'dbo.results.fastestLapTime_converted', 'fastestLapTime', 'COLUMN';
-EXEC sp_rename 'dbo.results.fastestLapSpeed_Decimal', 'fastestLapSpeed', 'COLUMN';
 EXEC sp_rename 'dbo.pitStops.duration_converted', 'duration', 'COLUMN';
 EXEC sp_rename 'dbo.qualifying.q1_converted', 'q1', 'COLUMN';
 EXEC sp_rename 'dbo.qualifying.q2_converted', 'q2', 'COLUMN';
 EXEC sp_rename 'dbo.qualifying.q3_converted', 'q3', 'COLUMN';
 EXEC sp_rename 'dbo.lapTimes.time_converted', 'time', 'COLUMN';
-EXEC sp_rename 'dbo.results.time_converted', 'time', 'COLUMN';
-EXEC sp_rename 'dbo.sprintResults.time_converted', 'time', 'COLUMN';

--- a/src/SequelFormula_foreign_keys.sql
+++ b/src/SequelFormula_foreign_keys.sql
@@ -20,6 +20,7 @@ ALTER TABLE [dbo].[Results] ADD CONSTRAINT FK_Results_RaceID FOREIGN KEY (RaceID
 ALTER TABLE [dbo].[Results] ADD CONSTRAINT FK_Results_ConstructorID FOREIGN KEY (ConstructorID) REFERENCES dbo.constructors (ConstructorID)
 ALTER TABLE [dbo].[Results] ADD CONSTRAINT FK_Results_StatusID FOREIGN KEY (StatusID) REFERENCES dbo.[Status] (StatusID)
 ALTER TABLE [dbo].[Results] ADD CONSTRAINT FK_Results_PositionTextID FOREIGN KEY (positionTextID) REFERENCES [dbo].[positionText] (positionTextID) 
+ALTER TABLE [dbo].[Results] ADD CONSTRAINT FK_Results_ResultTypeID FOREIGN KEY (resultType) REFERENCES [dbo].[resultType] (resultTypeID)
 
 /*Pit Stops*/
 ALTER TABLE [dbo].[PitStops] ADD CONSTRAINT FK_PitStops_DriverID FOREIGN KEY (driverID) REFERENCES dbo.drivers (driverID)

--- a/src/SequelFormula_tables.sql
+++ b/src/SequelFormula_tables.sql
@@ -313,12 +313,44 @@ CREATE TABLE [dbo].[driverNumbers]
 
 ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_driverNumberID PRIMARY KEY (driverNumberID);
 
-ALTER TABLE [dbo].[Results] ADD positionTextID INT;
+CREATE TABLE [dbo].[resultsNew]
+(
+	[resultId] [int] NOT NULL IDENTITY(1,1),
+	[resultType] [int] NOT NULL,
+	[raceId] [int] NOT NULL,
+	[driverId] [int] NOT NULL,
+	[constructorId] [int] NOT NULL,
+	[number] [int] NULL,
+	[grid] [int] NOT NULL DEFAULT 0,
+	[position] [int] NULL,
+	[positionOrder] [int] NOT NULL DEFAULT 0,
+	[points] [float] NOT NULL DEFAULT 0,
+	[laps] [int] NOT NULL DEFAULT 0,
+	[milliseconds] [int] NULL,
+	[fastestLap] [int] NULL,
+	[rank] [int] NULL DEFAULT 0,
+	[statusId] [int] NOT NULL DEFAULT 0,
+	[positionTextID] [int] NULL,
+	[fastestLapTime] [time](3) NULL,
+	[fastestLapSpeed] [decimal](18, 3) NULL,
+	[time] [time](3) NULL
+)
+
+ALTER TABLE [dbo].[resultsNew] ADD CONSTRAINT [PK_resultsNew_resultId] PRIMARY KEY (resultId);
+
+CREATE TABLE [dbo].[resultType]
+(
+	[resultTypeID] [int] NOT NULL,
+	[resultType] [varchar](255) NULL
+);
+
+ALTER TABLE [dbo].[resultType] ADD CONSTRAINT [PK_resultType_resultTypeID] PRIMARY KEY (resultTypeID);
+
+ALTER TABLE [dbo].[results] ADD positionTextID INT;
 ALTER TABLE [dbo].[results] ADD [timeDifference] DATETIME NULL; 
 ALTER TABLE [dbo].[results] ADD [fastestLapTime_Converted] TIME(3) NULL; 
 ALTER TABLE [dbo].[results] ADD [fastestLapSpeed_Decimal] DECIMAL(18,3) NULL; 
 ALTER TABLE [dbo].[results] ADD time_converted time(3);
-
 
 ALTER TABLE [dbo].[circuits] ADD locationID INT;
 ALTER TABLE [dbo].[circuits] ADD countryID INT;

--- a/src/supplementarydata/resultType.csv
+++ b/src/supplementarydata/resultType.csv
@@ -1,0 +1,3 @@
+﻿resultTypeID,resultType
+1,Race Result
+2,Sprint Race Result


### PR DESCRIPTION
Modifications were made to the SequelFormula_data_updates.sql to insert the data from results and sprintResults into a temp results table called resultsNew.

An additional column has been created called resultType which references a new table resultType this holds the result types due to two different types of results being stored side by side, main results and sprint results, these changes have been reflected in SequelFormula_tables.sql

This was tested against the latest version from main and the build was a success. 

This pull request will close #56 