### PR TITLE
Column & table rename

### DIFF
--- a/src/SequelFormula_data_updates.sql
+++ b/src/SequelFormula_data_updates.sql
@@ -292,7 +292,7 @@ GO
 INSERT INTO [dbo].[resultsNew]
 (
 	[raceId],
-	[resultType], 
+	[resultTypeId], 
 	[driverId], 
 	[constructorId], 
 	[number], 
@@ -337,7 +337,7 @@ GO
 INSERT INTO [dbo].[resultsNew]
 (
 	[raceId],
-	[resultType], 
+	[resultTypeId], 
 	[driverId],
 	[constructorId], 
 	[number], 
@@ -375,7 +375,7 @@ FROM
 
 GO
 
-INSERT INTO [dbo].[raceDriverConstructor] (resultID,driverID,constructorID)
+INSERT INTO [dbo].[resultDriverConstructor] (resultID,driverID,constructorID)
 SELECT 
 	[resultID],
 	[driverID],

--- a/src/SequelFormula_foreign_keys.sql
+++ b/src/SequelFormula_foreign_keys.sql
@@ -63,7 +63,7 @@ ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_driverID FOREI
 ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_constructorID FOREIGN KEY (constructorID) REFERENCES [dbo].[constructors] (constructorId);
 ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_season FOREIGN KEY (season) REFERENCES [dbo].[seasons](year);
 
-/*raceDriverConstructor*/
-ALTER TABLE [dbo].[raceDriverConstructor] ADD CONSTRAINT PK_raceDriverConstructor_resultID FOREIGN KEY (resultID) REFERENCES [dbo].[results] (resultID);
-ALTER TABLE [dbo].[raceDriverConstructor] ADD CONSTRAINT PK_raceDriverConstructor_driverID FOREIGN KEY (driverID) REFERENCES [dbo].[drivers] (driverID);
-ALTER TABLE [dbo].[raceDriverConstructor] ADD CONSTRAINT PK_raceDriverConstructor_constructorID FOREIGN KEY (constructorID) REFERENCES [dbo].[constructors] (constructorID);
+/*resultDriverConstructor*/
+ALTER TABLE [dbo].[resultDriverConstructor] ADD CONSTRAINT PK_resultDriverConstructor_resultID FOREIGN KEY (resultID) REFERENCES [dbo].[results] (resultID);
+ALTER TABLE [dbo].[resultDriverConstructor] ADD CONSTRAINT PK_resultDriverConstructor_driverID FOREIGN KEY (driverID) REFERENCES [dbo].[drivers] (driverID);
+ALTER TABLE [dbo].[resultDriverConstructor] ADD CONSTRAINT PK_resultDriverConstructor_constructorID FOREIGN KEY (constructorID) REFERENCES [dbo].[constructors] (constructorID);

--- a/src/SequelFormula_tables.sql
+++ b/src/SequelFormula_tables.sql
@@ -316,7 +316,7 @@ ALTER TABLE [dbo].[driverNumbers] ADD CONSTRAINT PK_driverNumbers_driverNumberID
 CREATE TABLE [dbo].[resultsNew]
 (
 	[resultId] [int] NOT NULL IDENTITY(1,1),
-	[resultType] [int] NOT NULL,
+	[resultTypeId] [int] NOT NULL,
 	[raceId] [int] NOT NULL,
 	[driverId] [int] NOT NULL,
 	[constructorId] [int] NOT NULL,
@@ -346,15 +346,15 @@ CREATE TABLE [dbo].[resultType]
 
 ALTER TABLE [dbo].[resultType] ADD CONSTRAINT [PK_resultType_resultTypeID] PRIMARY KEY (resultTypeID);
 
-CREATE TABLE [dbo].[raceDriverConstructor]
+CREATE TABLE [dbo].[resultDriverConstructor]
 (
-[raceDriverConstructorID] INT IDENTITY(1,1) NOT NULL,
+[resultDriverConstructorID] INT IDENTITY(1,1) NOT NULL,
 [resultID] INT NOT NULL,
 [driverID] INT NOT NULL,
 [constructorID] INT NOT NULL 
 );
 
-ALTER TABLE [dbo].[raceDriverConstructor] ADD CONSTRAINT PK_raceDriverConstructor_raceDriverConstructorID PRIMARY KEY (raceDriverConstructorID);
+ALTER TABLE [dbo].[resultDriverConstructor] ADD CONSTRAINT PK_resultDriverConstructor_resultDriverConstructorID PRIMARY KEY (resultDriverConstructorID);
 
 ALTER TABLE [dbo].[results] ADD positionTextID INT;
 ALTER TABLE [dbo].[results] ADD [timeDifference] DATETIME NULL; 


### PR DESCRIPTION
Renamed some of the columns to match the expected output. Renamed the raceDriverConstructor table to resultDriverConstructor to match its purpose.